### PR TITLE
Issue #13: Allow google identity provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,4 +51,10 @@ module "openshift" {
   public_certificate_pem              = "${module.domain.public_certificate_pem}"
   public_certificate_key              = "${module.domain.public_certificate_key}"
   public_certificate_intermediate_pem = "${module.domain.public_certificate_intermediate_pem}"
+
+  identity_providers         = "${var.identity_providers}"
+
+  google_client_id           = "${var.google_client_id}"
+  google_client_secret       = "${var.google_client_secret}"
+  google_client_domain       = "${var.google_client_domain}"
 }

--- a/modules/openshift/inventory.tf
+++ b/modules/openshift/inventory.tf
@@ -2,17 +2,22 @@ data "template_file" "template_inventory" {
   template = "${file("${path.module}/resources/template-inventory.yaml")}"
 
   vars {
-    platform_name                  = "${var.platform_name}"
-    ansible_user                   = "${var.bastion_ssh_user}"
-    rhn_username                   = "${var.rhn_username}"
-    rhn_password                   = "${var.rhn_password}"
-    rh_subscription_pool_id        = "${var.rh_subscription_pool_id}"
-    platform_domain                = "${var.platform_domain}"
-    master_domain                  = "${var.master_domain}"
-    openshift_deployment_type      = "${var.use_community ? "origin" : "openshift-enterprise"}"
-    openshift_major_version        = "${var.openshift_major_version}"
-    openshift_repos_enable_testing = "${var.use_community ? "true" : "false"}"
-    named_certificate              = "${(var.public_certificate_pem == "") ? false : true}"
+    platform_name                   = "${var.platform_name}"
+    ansible_user                    = "${var.bastion_ssh_user}"
+    rhn_username                    = "${var.rhn_username}"
+    rhn_password                    = "${var.rhn_password}"
+    rh_subscription_pool_id         = "${var.rh_subscription_pool_id}"
+    platform_domain                 = "${var.platform_domain}"
+    master_domain                   = "${var.master_domain}"
+    openshift_deployment_type       = "${var.use_community ? "origin" : "openshift-enterprise"}"
+    openshift_major_version         = "${var.openshift_major_version}"
+    openshift_repos_enable_testing  = "${var.use_community ? "true" : "false"}"
+    named_certificate               = "${(var.public_certificate_pem == "") ? false : true}"
+    use_allow_all_identity_provider = "${contains(var.identity_providers, "AllowAllIdentityProvider")}"
+    use_google_identity_provider    = "${contains(var.identity_providers, "GoogleIdentityProvider")}"
+    google_client_id                = "${var.google_client_id}"
+    google_client_secret            = "${var.google_client_secret}"
+    google_client_domain            = "${var.google_client_domain}"
   }
 }
 

--- a/modules/openshift/resources/template-inventory.yaml
+++ b/modules/openshift/resources/template-inventory.yaml
@@ -17,10 +17,18 @@ ${openshift_deployment_type == "openshift-enterprise" ? "#" : ""}    - {id: 'cen
     openshift_release: "${openshift_major_version}"
     openshift_repos_enable_testing: ${openshift_repos_enable_testing}
     openshift_master_identity_providers:
-      - name: 'test_identity_provider'
-        login: true
-        challenge: true
-        kind: 'AllowAllPasswordIdentityProvider'
+${use_allow_all_identity_provider == "true" ? "" : "#"}      - name: 'all'
+${use_allow_all_identity_provider == "true" ? "" : "#"}        login: true
+${use_allow_all_identity_provider == "true" ? "" : "#"}        challenge: true
+${use_allow_all_identity_provider == "true" ? "" : "#"}        kind: 'AllowAllPasswordIdentityProvider'
+${use_google_identity_provider == "true" ? "" : "#"}      - name: google
+${use_google_identity_provider == "true" ? "" : "#"}        challenge: false
+${use_google_identity_provider == "true" ? "" : "#"}        login: true
+${use_google_identity_provider == "true" ? "" : "#"}        mappingMethod: claim
+${use_google_identity_provider == "true" ? "" : "#"}        kind: GoogleIdentityProvider
+${use_google_identity_provider == "true" ? "" : "#"}        clientID: "${google_client_id}"
+${use_google_identity_provider == "true" ? "" : "#"}        clientSecret: "${google_client_secret}"
+${use_google_identity_provider == "true" ? "" : "#"}        hostedDomain: "${google_client_domain}"
     os_sdn_network_plugin_name: 'redhat/openshift-ovs-networkpolicy'
     openshift_disable_check: 'disk_availability,memory_availability,docker_image_availability'
     openshift_master_cluster_hostname: ${master_domain}

--- a/modules/openshift/variables.tf
+++ b/modules/openshift/variables.tf
@@ -1,5 +1,31 @@
 variable "platform_name" {}
 
+variable "identity_providers" {
+    type        = "list"
+    description = "The identity providers to enable (AllowAllIdentityProvider, GoogleIdentityProvider)"
+    default     = [
+        "AllowAllIdentityProvider"
+    ]
+}
+
+variable "google_client_id" {
+    type        = "string"
+    description = "The Google client id used by the GoogleIdentityProvider"
+    default     = ""
+}
+
+variable "google_client_secret" {
+    type        = "string"
+    description = "The client secret used by the GoogleIdentityProvider"
+    default     = ""
+}
+
+variable "google_client_domain" {
+    type        = "string"
+    description = "The domain used by the GoogleIdentityProvider"
+    default     = ""
+}
+
 variable "rh_subscription_pool_id" {
   description = "Red Hat subscription pool id for OpenShift Container Platform"
   default     = ""

--- a/variables.tf
+++ b/variables.tf
@@ -64,3 +64,29 @@ variable "platform_domain" {
 variable "platform_domain_administrator_email" {
   default = ""
 }
+
+variable "identity_providers" {
+    type        = "list"
+    description = "The identity providers to enable (AllowAllIdentityProvider, GoogleIdentityProvider)"
+    default     = [
+        "AllowAllIdentityProvider"
+    ]
+}
+
+variable "google_client_id" {
+    type        = "string"
+    description = "The Google client id used by the GoogleIdentityProvider"
+    default     = ""
+}
+
+variable "google_client_secret" {
+    type        = "string"
+    description = "The client secret used by the GoogleIdentityProvider"
+    default     = ""
+}
+
+variable "google_client_domain" {
+    type        = "string"
+    description = "The domain used by the GoogleIdentityProvider"
+    default     = ""
+}


### PR DESCRIPTION
This at least establishes the framework by which multiple identity providers can be defined and configured though it stops short of enabling anything other than the `AllowAllIdentityProvider` and the `GoogleIdentityProvider`.  This is also related to #9.