### PR TITLE
Issue #12: Allow accounts without access to gold images

### DIFF
--- a/modules/infra/ami.tf
+++ b/modules/infra/ami.tf
@@ -1,61 +1,33 @@
-data "aws_ami" "commercial" {
-  most_recent = true
-
-  owners = ["309956199498"]
-
-  filter {
-    name   = "architecture"
-    values = ["x86_64"]
-  }
-
-  filter {
-    name   = "root-device-type"
-    values = ["ebs"]
-  }
-
-  filter {
-    name   = "name"
-    values = ["RHEL-7.5_HVM_GA-????????-x86_64-*-Access2-*"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
-    name   = "block-device-mapping.volume-type"
-    values = ["gp2"]
-  }
-}
-
-data "aws_ami" "community" {
-  most_recent = true
-
-  owners = ["679593333241"]
-
-  filter {
-    name   = "architecture"
-    values = ["x86_64"]
-  }
-
-  filter {
-    name   = "root-device-type"
-    values = ["ebs"]
-  }
-
-  filter {
-    name   = "name"
-    values = ["CentOS Linux 7 x86_64 HVM EBS *"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-}
 
 locals {
-  base_image_id               = "${var.use_community ? data.aws_ami.community.image_id : data.aws_ami.commercial.image_id}"
-  base_image_root_device_name = "${var.use_community ? data.aws_ami.community.root_device_name : data.aws_ami.commercial.root_device_name}"
+  base_image_owners           = "${var.use_community ? "679593333241" : "309956199498"}"
+  base_image_name             = "${var.use_community ? "CentOS Linux 7 x86_64 HVM EBS *" : "RHEL-7.5_HVM_GA-????????-x86_64-*-Access2-*"}"
+  base_image_id               = "${data.aws_ami.base_image.image_id}"
+  base_image_root_device_name = "${data.aws_ami.base_image.root_device_name}"
+}
+
+data "aws_ami" "base_image" {
+  most_recent = true
+
+  owners = ["${local.base_image_owners}"]
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "name"
+    values = ["${local.base_image_name}"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
 }


### PR DESCRIPTION
As per the description in #12, having an `aws_ami` data resource that does not return a single result causes the runs to fail.  This gets around that by consolidating two (i.e. `commercial` and `community`) `aws_ami` resources into a single resource and parameterizing the `owner` and `name` filters as appropriate based on the `use_community` variable.

Note that this dropped the `block-device-mapping.volume-type` filter as the other filter criteria resulted in a single AMI for commercial images without that filter.