### PR TITLE
prevent subnet conflicts regardless of az count

### DIFF
--- a/modules/network/private_network.tf
+++ b/modules/network/private_network.tf
@@ -9,7 +9,7 @@ resource "aws_subnet" "private" {
   count             = "${local.private_subnet_count}"
   vpc_id            = "${aws_vpc.platform.id}"
   availability_zone = "${element(data.aws_availability_zones.available.names, count.index)}"
-  cidr_block        = "${cidrsubnet(aws_vpc.platform.cidr_block, 3, count.index)}"
+  cidr_block        = "${cidrsubnet(aws_vpc.platform.cidr_block, ceil(log(local.private_subnet_count + local.public_subnet_count, 2)), count.index)}"
 
   map_public_ip_on_launch = true
 

--- a/modules/network/public_network.tf
+++ b/modules/network/public_network.tf
@@ -8,7 +8,7 @@ resource "aws_subnet" "public" {
   count                   = "${local.public_subnet_count}"
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
   vpc_id                  = "${aws_vpc.platform.id}"
-  cidr_block              = "${cidrsubnet(aws_vpc.platform.cidr_block, 4, 8 + count.index)}"
+  cidr_block              = "${cidrsubnet(aws_vpc.platform.cidr_block, ceil(log(local.private_subnet_count + local.public_subnet_count, 2)), local.private_subnet_count + count.index)}"
   map_public_ip_on_launch = true
 
   tags = "${map(


### PR DESCRIPTION
The current implementation will fail when the number of az's exceeds four.  This implementation bases the allocates half the cidr block to the private subnets and half to the public subnets regardless of the count of availability zone. 