### PR TITLE
Remove extraneous dollar sign in template

### DIFF
--- a/modules/infra/resources/bastion-init.yml
+++ b/modules/infra/resources/bastion-init.yml
@@ -13,7 +13,7 @@ write_files:
     for ALLOC_ID in `aws ec2 describe-addresses --filter "Name=domain,Values=vpc" "Name=tag:Role,Values=bastion" "Name=tag:kubernetes.io/cluster/${platform_name},Values=owned" | /usr/local/bin/jq '.Addresses[].AllocationId' | cut -d '"' -f 2`
     do
       aws ec2 associate-address --instance-id $${INSTANCE_ID} --allocation-id $${ALLOC_ID} --no-allow-reassociation
-      STATUS=$$?
+      STATUS=$?
       if [ 0 = $${STATUS} ] ; then
         exit 0
       fi


### PR DESCRIPTION
This is a minor fix to correct an extra dollar sign in the bastion init script template.  Looks like a global replace on `$` to `$$` was performed when a global replace on `${` to `$${` should have been performed.  In short, the template engine does not replace `$$?` with anything and thus we are not actually checking the error status of the last command we are checking the PID of the bash command with a `?` on the end.

```
$ echo $$?
86758?
```