### PR TITLE
Add new tag to Master Nodes

### DIFF
--- a/modules/infra/master.tf
+++ b/modules/infra/master.tf
@@ -33,7 +33,8 @@ resource "aws_launch_template" "master" {
       "kubernetes.io/cluster/${var.platform_name}", "owned",
       "Name", "${var.platform_name}-master",
       "Role", "master,node",
-      "openshift_node_group_name", "${var.infra_node_count > 0 ? "node-config-master" : "node-config-master-infra"}"
+      "openshift_node_group_name", "${var.infra_node_count > 0 ? "node-config-master" : "node-config-master-infra"}",
+      "kubernetes.io/role/master", "true"
     )}"
   }
 


### PR DESCRIPTION
At times, dynamic volumes can be assigned to an zone that a master node exists but a compute nodes does not.  This [PR](https://github.com/kubernetes/kubernetes/pull/41702) in the kubernetes code added the ability to check for the tag `kubernetes.io/role/master` on nodes, and avoids creating a volume in a zone where only a master exists.

This PR adds the tag to the master nodes to allow for the upstream kubernetes node check to function.